### PR TITLE
ResponseFactory is passed to service instead of response prototype

### DIFF
--- a/src/BasicAccess.php
+++ b/src/BasicAccess.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-authentication-basic for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-authentication-basic/blob/master/LICENSE.md
  *     New BSD License
  */
@@ -27,30 +27,24 @@ class BasicAccess implements AuthenticationInterface
     protected $realm;
 
     /**
-     * @var ResponseInterface
+     * @var callable
      */
-    protected $responsePrototype;
+    protected $responseFactory;
 
-    /**
-     * Constructor
-     *
-     * @param UserRepositoryInterface $repository
-     * @param string $realm
-     * @param ResponseInterface $responsePrototype
-     */
     public function __construct(
         UserRepositoryInterface $repository,
         string $realm,
-        ResponseInterface $responsePrototype
+        callable $responseFactory
     ) {
         $this->repository = $repository;
         $this->realm = $realm;
-        $this->responsePrototype = $responsePrototype;
+
+        // Ensures type safety of the composed factory
+        $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
+            return $responseFactory();
+        };
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function authenticate(ServerRequestInterface $request) : ?UserInterface
     {
         $authHeader = $request->getHeader('Authorization');
@@ -67,12 +61,9 @@ class BasicAccess implements AuthenticationInterface
         return $this->repository->authenticate($username, $password);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function unauthorizedResponse(ServerRequestInterface $request) : ResponseInterface
     {
-        return $this->responsePrototype
+        return ($this->responseFactory)()
             ->withHeader(
                 'WWW-Authenticate',
                 sprintf('Basic realm="%s"', $this->realm)

--- a/src/BasicAccessFactory.php
+++ b/src/BasicAccessFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-authentication-basic for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-authentication-basic/blob/master/LICENSE.md
  *     New BSD License
  */
@@ -9,14 +9,12 @@
 namespace Zend\Expressive\Authentication\Basic;
 
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
 use Zend\Expressive\Authentication\Exception;
-use Zend\Expressive\Authentication\ResponsePrototypeTrait;
 use Zend\Expressive\Authentication\UserRepositoryInterface;
 
 class BasicAccessFactory
 {
-    use ResponsePrototypeTrait;
-
     public function __invoke(ContainerInterface $container) : BasicAccess
     {
         $userRegister = $container->has(UserRepositoryInterface::class)
@@ -40,7 +38,7 @@ class BasicAccessFactory
         return new BasicAccess(
             $userRegister,
             $realm,
-            $this->getResponsePrototype($container)
+            $container->get(ResponseInterface::class)
         );
     }
 }

--- a/test/BasicAccessTest.php
+++ b/test/BasicAccessTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive-authentication-basic for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive-authentication-basic/blob/master/LICENSE.md
  *     New BSD License
  */
@@ -32,12 +32,18 @@ class BasicAccessTest extends TestCase
     /** @var ResponseInterface|ObjectProphecy */
     private $responsePrototype;
 
+    /** @var callable */
+    private $responseFactory;
+
     protected function setUp()
     {
         $this->request = $this->prophesize(ServerRequestInterface::class);
         $this->userRepository = $this->prophesize(UserRepositoryInterface::class);
         $this->authenticatedUser = $this->prophesize(UserInterface::class);
         $this->responsePrototype = $this->prophesize(ResponseInterface::class);
+        $this->responseFactory = function () {
+            return $this->responsePrototype->reveal();
+        };
     }
 
     public function testConstructor()
@@ -45,7 +51,7 @@ class BasicAccessTest extends TestCase
         $basicAccess = new BasicAccess(
             $this->userRepository->reveal(),
             'test',
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
         $this->assertInstanceOf(AuthenticationInterface::class, $basicAccess);
     }
@@ -59,7 +65,7 @@ class BasicAccessTest extends TestCase
         $basicAccess = new BasicAccess(
             $this->userRepository->reveal(),
             'test',
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
         $this->assertNull($basicAccess->authenticate($this->request->reveal()));
     }
@@ -73,7 +79,7 @@ class BasicAccessTest extends TestCase
         $basicAccess = new BasicAccess(
             $this->userRepository->reveal(),
             'test',
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
 
         $this->assertNull($basicAccess->authenticate($this->request->reveal()));
@@ -98,7 +104,7 @@ class BasicAccessTest extends TestCase
         $basicAccess = new BasicAccess(
             $this->userRepository->reveal(),
             'test',
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
 
         $user = $basicAccess->authenticate($this->request->reveal());
@@ -119,7 +125,7 @@ class BasicAccessTest extends TestCase
         $basicAccess = new BasicAccess(
             $this->userRepository->reveal(),
             'test',
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
 
         $this->assertNull($basicAccess->authenticate($this->request->reveal()));
@@ -140,7 +146,7 @@ class BasicAccessTest extends TestCase
         $basicAccess = new BasicAccess(
             $this->userRepository->reveal(),
             'test',
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
 
         $response = $basicAccess->unauthorizedResponse($this->request->reveal());


### PR DESCRIPTION
Before the response prototype was passed to the service so the second
fetch of the service used the same response.
The brand new response should be created each time the service is used.

Ref:
- https://github.com/zendframework/zend-expressive-authentication-oauth2/issues/16#issuecomment-368691028
- https://github.com/zendframework/zend-expressive-authentication/pull/19