### PR TITLE
Fixes site name for MkDocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_dir: docs/html
 pages:
     - index.md
     - Introduction: intro.md
-site_name: Component Name Goes Here
+site_name: zend-expressive-authentication-basic
 site_description: 'HTTP Basic Authentication adapter for zend-expressive-authentication.'
 repo_url: 'https://github.com/zendframework/zend-expressive-authentication-basic'
 copyright: 'Copyright (c) 2017 <a href="http://www.zend.com/">Zend Technologies USA Inc.</a>'


### PR DESCRIPTION
[Paweł Świszcz found this bug and reported it on Slack:](https://zendframework.slack.com/archives/CAP4J90LW/p1527236383000211)

https://github.com/zendframework/zend-expressive-authentication-basic/blob/e340d55337ed65a8f064640e7e48c3bac9034df1/mkdocs.yml#L6

This results in a wrong header and installation command in the documentation:

> ## Component Name Goes Here
> 
> `$ composer require zendframework/Component Name Goes Here`

https://docs.zendframework.com/zend-expressive-authentication-basic/

