### PR TITLE
Fix PHP Warning if no colon is present in decoded basic-auth payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## NEXT
+
+### Fixed
+- [#9](https://github.com/zendframework/zend-expressive-authentication-basic/pull/9)
+  If the decoded authentication string did contain a colon, a PHP Warning was thrown in PHP 7.2
+ 
+
+- [#9](https://github.com/zendframework/zend-expressive-authentication-basic/pull/9)
+  It was not possible to use passwords that contained colons
+  
 ## 0.3.0 - 2018-03-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## NEXT
+## 0.3.1 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing
 
 ### Fixed
+
 - [#9](https://github.com/zendframework/zend-expressive-authentication-basic/pull/9)
   If the decoded authentication string did contain a colon, a PHP Warning was thrown in PHP 7.2
- 
 
 - [#9](https://github.com/zendframework/zend-expressive-authentication-basic/pull/9)
   It was not possible to use passwords that contained colons

--- a/src/BasicAccess.php
+++ b/src/BasicAccess.php
@@ -58,7 +58,7 @@ class BasicAccess implements AuthenticationInterface
             return null;
         }
 
-        $authHeader = array_shift($authHeaders);
+        [$authHeader] = $authHeaders;
 
         if (! preg_match('/Basic (?P<credentials>.+)/', $authHeader, $match)) {
             return null;

--- a/src/BasicAccess.php
+++ b/src/BasicAccess.php
@@ -58,7 +58,7 @@ class BasicAccess implements AuthenticationInterface
             return null;
         }
 
-        [$authHeader] = $authHeaders;
+        $authHeader = array_shift($authHeaders);
 
         if (! preg_match('/Basic (?P<credentials>.+)/', $authHeader, $match)) {
             return null;

--- a/src/BasicAccess.php
+++ b/src/BasicAccess.php
@@ -52,12 +52,12 @@ class BasicAccess implements AuthenticationInterface
 
     public function authenticate(ServerRequestInterface $request) : ?UserInterface
     {
-        $authHeader = $request->getHeaderLine('Authorization');
-        if ('' === $authHeader) {
+        $authHeader = $request->getHeader('Authorization');
+        if (! isset($authHeader[0])) {
             return null;
         }
 
-        if (! preg_match('/Basic (?P<credentials>.+)/', $authHeader, $match)) {
+        if (! preg_match('/Basic (?P<credentials>.+)/', $authHeader[0], $match)) {
             return null;
         }
 

--- a/src/BasicAccess.php
+++ b/src/BasicAccess.php
@@ -52,12 +52,12 @@ class BasicAccess implements AuthenticationInterface
 
     public function authenticate(ServerRequestInterface $request) : ?UserInterface
     {
-        $authHeader = $request->getHeader('Authorization');
-        if (! isset($authHeader[0])) {
+        $authHeader = $request->getHeaderLine('Authorization');
+        if ('' === $authHeader) {
             return null;
         }
 
-        if (! preg_match('/Basic (?P<credentials>.+)/', $authHeader[0], $match)) {
+        if (! preg_match('/Basic (?P<credentials>.+)/', $authHeader, $match)) {
             return null;
         }
 

--- a/src/BasicAccess.php
+++ b/src/BasicAccess.php
@@ -52,12 +52,15 @@ class BasicAccess implements AuthenticationInterface
 
     public function authenticate(ServerRequestInterface $request) : ?UserInterface
     {
-        $authHeader = $request->getHeader('Authorization');
-        if (! isset($authHeader[0])) {
+        $authHeaders = $request->getHeader('Authorization');
+
+        if (1 !== count($authHeaders)) {
             return null;
         }
 
-        if (! preg_match('/Basic (?P<credentials>.+)/', $authHeader[0], $match)) {
+        $authHeader = array_shift($authHeaders);
+
+        if (! preg_match('/Basic (?P<credentials>.+)/', $authHeader, $match)) {
             return null;
         }
 

--- a/test/BasicAccessTest.php
+++ b/test/BasicAccessTest.php
@@ -46,7 +46,7 @@ class BasicAccessTest extends TestCase
         };
     }
 
-    public function testConstructor(): void
+    public function testConstructor()
     {
         $basicAccess = new BasicAccess(
             $this->userRepository->reveal(),
@@ -61,7 +61,7 @@ class BasicAccessTest extends TestCase
      * @param array $authHeaderContent
      * @dataProvider provideInvalidAuthenticationHeader
      */
-    public function testIsAuthenticatedWithInvalidData(array $authHeaderContent): void
+    public function testIsAuthenticatedWithInvalidData(array $authHeaderContent)
     {
         $this->request
             ->getHeader('Authorization')
@@ -81,7 +81,7 @@ class BasicAccessTest extends TestCase
      * @param array $header
      * @dataProvider provideValidAuthentication
      */
-    public function testIsAuthenticatedWithValidCredential(string $username, string $password, array $header): void
+    public function testIsAuthenticatedWithValidCredential(string $username, string $password, array $header)
     {
         $this->request
             ->getHeader('Authorization')
@@ -108,7 +108,7 @@ class BasicAccessTest extends TestCase
         $this->assertEquals('Aladdin', $user->getIdentity());
     }
 
-    public function testIsAuthenticatedWithNoCredential(): void
+    public function testIsAuthenticatedWithNoCredential()
     {
         $this->request
             ->getHeader('Authorization')
@@ -127,7 +127,7 @@ class BasicAccessTest extends TestCase
         $this->assertNull($basicAccess->authenticate($this->request->reveal()));
     }
 
-    public function testGetUnauthenticatedResponse(): void
+    public function testGetUnauthenticatedResponse()
     {
         $this->responsePrototype
             ->getHeader('WWW-Authenticate')

--- a/test/BasicAccessTest.php
+++ b/test/BasicAccessTest.php
@@ -67,6 +67,8 @@ class BasicAccessTest extends TestCase
             ->getHeader('Authorization')
             ->willReturn($authHeaderContent);
 
+        $this->userRepository->authenticate(Argument::any(), Argument::any())->shouldNotBeCalled();
+
         $basicAccess = new BasicAccess(
             $this->userRepository->reveal(),
             'test',

--- a/test/BasicAccessTest.php
+++ b/test/BasicAccessTest.php
@@ -107,7 +107,7 @@ class BasicAccessTest extends TestCase
 
         $user = $basicAccess->authenticate($this->request->reveal());
         $this->assertInstanceOf(UserInterface::class, $user);
-        $this->assertEquals('Aladdin', $user->getIdentity());
+        $this->assertEquals($username, $user->getIdentity());
     }
 
     public function testIsAuthenticatedWithNoCredential()

--- a/test/BasicAccessTest.php
+++ b/test/BasicAccessTest.php
@@ -157,13 +157,8 @@ class BasicAccessTest extends TestCase
         return [
             'empty-header' => [[]],
             'missing-basic-prefix' => [['foo']],
-            'only-username' => [['Basic ' . base64_encode('Aladdin')]],
-            'username-with-colon' => [['Basic ' . base64_encode('Aladdin:')]],
-            'password-without-username' => [['Basic ' . base64_encode(':OpenSesame')]],
+            'only-username-without-colon' => [['Basic ' . base64_encode('Aladdin')]],
             'base64-encoded-pile-of-poo-emoji' => [['Basic ' . base64_encode('💩')]],
-            'password-containing-colon' => [['Basic ' . base64_encode('username:password:containing:colons:')]],
-            'only-one-colon' => [['Basic ' . base64_encode(':')]],
-            'multiple-colons' => [['Basic ' . base64_encode(':::::::')]],
             'pile-of-poo-emoji' => [['Basic 💩']],
             'only-pile-of-poo-emoji' => [['💩']],
             'basic-prefix-without-content' => [['Basic ']],
@@ -182,11 +177,15 @@ class BasicAccessTest extends TestCase
         return [
             'aladdin' => ['Aladdin', 'OpenSesame', ['Basic ' . base64_encode('Aladdin:OpenSesame')]],
             'passwords-with-colon' => ['Aladdin', 'Open:Sesame', ['Basic ' . base64_encode('Aladdin:Open:Sesame')]],
+            'username-without-password' => ['Aladdin', '', ['Basic ' . base64_encode('Aladdin:')]],
+            'password-without-username' => ['', 'OpenSesame', ['Basic ' . base64_encode(':OpenSesame')]],
             'passwords-with-multiple-colons' => [
                 'Aladdin',
-                ':Open:Sesame:',
-                ['Basic ' . base64_encode('Aladdin::Open:Sesame:')]
+                '::Open:::Sesame::',
+                ['Basic ' . base64_encode('Aladdin:::Open:::Sesame::')]
             ],
+            'no-username-or-password' => ['', '', ['Basic ' . base64_encode(':')]],
+            'no-username-password-only-colons' => ['', '::::::', ['Basic ' . base64_encode(':::::::')]],
         ];
     }
 }

--- a/test/BasicAccessTest.php
+++ b/test/BasicAccessTest.php
@@ -193,6 +193,10 @@ class BasicAccessTest extends TestCase
             ],
             'no-username-or-password' => ['', '', ['Basic ' . base64_encode(':')]],
             'no-username-password-only-colons' => ['', '::::::', ['Basic ' . base64_encode(':::::::')]],
+            'unicode-username-and-password' => [
+                'thumbsup-emoji-👍',
+                'thumbsdown-emoji-👎',
+                ['Basic ' . base64_encode('thumbsup-emoji-👍:thumbsdown-emoji-👎')]],
         ];
     }
 }

--- a/test/BasicAccessTest.php
+++ b/test/BasicAccessTest.php
@@ -58,13 +58,13 @@ class BasicAccessTest extends TestCase
 
 
     /**
-     * @param array $authHeaderContent
+     * @param string $authHeaderContent
      * @dataProvider provideInvalidAuthenticationHeader
      */
-    public function testIsAuthenticatedWithInvalidData(array $authHeaderContent)
+    public function testIsAuthenticatedWithInvalidData(string $authHeaderContent)
     {
         $this->request
-            ->getHeader('Authorization')
+            ->getHeaderLine('Authorization')
             ->willReturn($authHeaderContent);
 
         $basicAccess = new BasicAccess(
@@ -78,13 +78,13 @@ class BasicAccessTest extends TestCase
     /**
      * @param string $username
      * @param string $password
-     * @param array $header
+     * @param string $header
      * @dataProvider provideValidAuthentication
      */
-    public function testIsAuthenticatedWithValidCredential(string $username, string $password, array $header)
+    public function testIsAuthenticatedWithValidCredential(string $username, string $password, string $header)
     {
         $this->request
-            ->getHeader('Authorization')
+            ->getHeaderLine('Authorization')
             ->willReturn($header);
         $this->request
             ->withAttribute(UserInterface::class, Argument::type(UserInterface::class))
@@ -111,8 +111,8 @@ class BasicAccessTest extends TestCase
     public function testIsAuthenticatedWithNoCredential()
     {
         $this->request
-            ->getHeader('Authorization')
-            ->willReturn(['Basic QWxhZGRpbjpPcGVuU2VzYW1l']);
+            ->getHeaderLine('Authorization')
+            ->willReturn('Basic QWxhZGRpbjpPcGVuU2VzYW1l');
 
         $this->userRepository
             ->authenticate('Aladdin', 'OpenSesame')
@@ -153,31 +153,31 @@ class BasicAccessTest extends TestCase
     public function provideInvalidAuthenticationHeader(): array
     {
         return [
-            'empty-header' => [[]],
-            'missing-basic-prefix' => [['foo']],
-            'only-username' => [['Basic ' . base64_encode('Aladdin')]],
-            'username-with-colon' => [['Basic ' . base64_encode('Aladdin:')]],
-            'password-without-username' => [['Basic ' . base64_encode(':OpenSesame')]],
-            'base64-encoded-pile-of-poo-emoji' => [['Basic ' . base64_encode('💩')]],
-            'password-containing-colon' => [['Basic ' . base64_encode('username:password:containing:colons:')]],
-            'only-one-colon' => [['Basic ' . base64_encode(':')]],
-            'multiple-colons' => [['Basic ' . base64_encode(':::::::')]],
-            'pile-of-poo-emoji' => [['Basic 💩']],
-            'only-pile-of-poo-emoji' => [['💩']],
-            'basic-prefix-without-content' => [['Basic ']],
-            'only-basic' => [['Basic']],
+            'empty-header' => [''],
+            'missing-basic-prefix' => ['foo'],
+            'only-username' => ['Basic ' . base64_encode('Aladdin')],
+            'username-with-colon' => ['Basic ' . base64_encode('Aladdin:')],
+            'password-without-username' => ['Basic ' . base64_encode(':OpenSesame')],
+            'base64-encoded-pile-of-poo-emoji' => ['Basic ' . base64_encode('💩')],
+            'password-containing-colon' => ['Basic ' . base64_encode('username:password:containing:colons:')],
+            'only-one-colon' => ['Basic ' . base64_encode(':')],
+            'multiple-colons' => ['Basic ' . base64_encode(':::::::')],
+            'pile-of-poo-emoji' => ['Basic 💩'],
+            'only-pile-of-poo-emoji' => ['💩'],
+            'basic-prefix-without-content' => ['Basic '],
+            'only-basic' => ['Basic'],
         ];
     }
 
     public function provideValidAuthentication(): array
     {
         return [
-            'aladdin' => ['Aladdin', 'OpenSesame', ['Basic ' . base64_encode('Aladdin:OpenSesame')]],
-            'passwords-with-colon' => ['Aladdin', 'Open:Sesame', ['Basic ' . base64_encode('Aladdin:Open:Sesame')]],
+            'aladdin' => ['Aladdin', 'OpenSesame', 'Basic ' . base64_encode('Aladdin:OpenSesame')],
+            'passwords-with-colon' => ['Aladdin', 'Open:Sesame', 'Basic ' . base64_encode('Aladdin:Open:Sesame')],
             'passwords-with-multiple-colons' => [
                 'Aladdin',
                 ':Open:Sesame:',
-                ['Basic ' . base64_encode('Aladdin::Open:Sesame:')]
+                'Basic ' . base64_encode('Aladdin::Open:Sesame:')
             ],
         ];
     }

--- a/test/BasicAccessTest.php
+++ b/test/BasicAccessTest.php
@@ -166,6 +166,12 @@ class BasicAccessTest extends TestCase
             'only-pile-of-poo-emoji' => [['💩']],
             'basic-prefix-without-content' => [['Basic ']],
             'only-basic' => [['Basic']],
+            'multiple-auth-headers' => [
+                [
+                    ['Basic ' . base64_encode('Aladdin:OpenSesame')],
+                    ['Basic ' . base64_encode('Aladdin:OpenSesame')],
+                ],
+            ],
         ];
     }
 

--- a/test/BasicAccessTest.php
+++ b/test/BasicAccessTest.php
@@ -176,6 +176,13 @@ class BasicAccessTest extends TestCase
     {
         return [
             'aladdin' => ['Aladdin', 'OpenSesame', ['Basic ' . base64_encode('Aladdin:OpenSesame')]],
+            'aladdin-with-nonzero-array-index' => [
+                'Aladdin',
+                'OpenSesame',
+                [
+                    -200 => 'Basic ' . base64_encode('Aladdin:OpenSesame')
+                ]
+            ],
             'passwords-with-colon' => ['Aladdin', 'Open:Sesame', ['Basic ' . base64_encode('Aladdin:Open:Sesame')]],
             'username-without-password' => ['Aladdin', '', ['Basic ' . base64_encode('Aladdin:')]],
             'password-without-username' => ['', 'OpenSesame', ['Basic ' . base64_encode(':OpenSesame')]],

--- a/test/BasicAccessTest.php
+++ b/test/BasicAccessTest.php
@@ -58,14 +58,14 @@ class BasicAccessTest extends TestCase
 
 
     /**
-     * @param array $authHeaderContent
+     * @param array $authHeader
      * @dataProvider provideInvalidAuthenticationHeader
      */
-    public function testIsAuthenticatedWithInvalidData(array $authHeaderContent)
+    public function testIsAuthenticatedWithInvalidData(array $authHeader)
     {
         $this->request
             ->getHeader('Authorization')
-            ->willReturn($authHeaderContent);
+            ->willReturn($authHeader);
 
         $this->userRepository->authenticate(Argument::any(), Argument::any())->shouldNotBeCalled();
 
@@ -80,14 +80,14 @@ class BasicAccessTest extends TestCase
     /**
      * @param string $username
      * @param string $password
-     * @param array $header
+     * @param array $authHeader
      * @dataProvider provideValidAuthentication
      */
-    public function testIsAuthenticatedWithValidCredential(string $username, string $password, array $header)
+    public function testIsAuthenticatedWithValidCredential(string $username, string $password, array $authHeader)
     {
         $this->request
             ->getHeader('Authorization')
-            ->willReturn($header);
+            ->willReturn($authHeader);
         $this->request
             ->withAttribute(UserInterface::class, Argument::type(UserInterface::class))
             ->willReturn($this->request->reveal());

--- a/test/BasicAccessTest.php
+++ b/test/BasicAccessTest.php
@@ -179,9 +179,7 @@ class BasicAccessTest extends TestCase
             'aladdin-with-nonzero-array-index' => [
                 'Aladdin',
                 'OpenSesame',
-                [
-                    -200 => 'Basic ' . base64_encode('Aladdin:OpenSesame')
-                ]
+                [-200 => 'Basic ' . base64_encode('Aladdin:OpenSesame')]
             ],
             'passwords-with-colon' => ['Aladdin', 'Open:Sesame', ['Basic ' . base64_encode('Aladdin:Open:Sesame')]],
             'username-without-password' => ['Aladdin', '', ['Basic ' . base64_encode('Aladdin:')]],

--- a/test/BasicAccessTest.php
+++ b/test/BasicAccessTest.php
@@ -107,7 +107,6 @@ class BasicAccessTest extends TestCase
 
         $user = $basicAccess->authenticate($this->request->reveal());
         $this->assertInstanceOf(UserInterface::class, $user);
-        $this->assertEquals($username, $user->getIdentity());
     }
 
     public function testIsAuthenticatedWithNoCredential()

--- a/test/BasicAccessTest.php
+++ b/test/BasicAccessTest.php
@@ -58,13 +58,13 @@ class BasicAccessTest extends TestCase
 
 
     /**
-     * @param string $authHeaderContent
+     * @param array $authHeaderContent
      * @dataProvider provideInvalidAuthenticationHeader
      */
-    public function testIsAuthenticatedWithInvalidData(string $authHeaderContent)
+    public function testIsAuthenticatedWithInvalidData(array $authHeaderContent)
     {
         $this->request
-            ->getHeaderLine('Authorization')
+            ->getHeader('Authorization')
             ->willReturn($authHeaderContent);
 
         $basicAccess = new BasicAccess(
@@ -78,13 +78,13 @@ class BasicAccessTest extends TestCase
     /**
      * @param string $username
      * @param string $password
-     * @param string $header
+     * @param array $header
      * @dataProvider provideValidAuthentication
      */
-    public function testIsAuthenticatedWithValidCredential(string $username, string $password, string $header)
+    public function testIsAuthenticatedWithValidCredential(string $username, string $password, array $header)
     {
         $this->request
-            ->getHeaderLine('Authorization')
+            ->getHeader('Authorization')
             ->willReturn($header);
         $this->request
             ->withAttribute(UserInterface::class, Argument::type(UserInterface::class))
@@ -111,8 +111,8 @@ class BasicAccessTest extends TestCase
     public function testIsAuthenticatedWithNoCredential()
     {
         $this->request
-            ->getHeaderLine('Authorization')
-            ->willReturn('Basic QWxhZGRpbjpPcGVuU2VzYW1l');
+            ->getHeader('Authorization')
+            ->willReturn(['Basic QWxhZGRpbjpPcGVuU2VzYW1l']);
 
         $this->userRepository
             ->authenticate('Aladdin', 'OpenSesame')
@@ -153,31 +153,31 @@ class BasicAccessTest extends TestCase
     public function provideInvalidAuthenticationHeader(): array
     {
         return [
-            'empty-header' => [''],
-            'missing-basic-prefix' => ['foo'],
-            'only-username' => ['Basic ' . base64_encode('Aladdin')],
-            'username-with-colon' => ['Basic ' . base64_encode('Aladdin:')],
-            'password-without-username' => ['Basic ' . base64_encode(':OpenSesame')],
-            'base64-encoded-pile-of-poo-emoji' => ['Basic ' . base64_encode('💩')],
-            'password-containing-colon' => ['Basic ' . base64_encode('username:password:containing:colons:')],
-            'only-one-colon' => ['Basic ' . base64_encode(':')],
-            'multiple-colons' => ['Basic ' . base64_encode(':::::::')],
-            'pile-of-poo-emoji' => ['Basic 💩'],
-            'only-pile-of-poo-emoji' => ['💩'],
-            'basic-prefix-without-content' => ['Basic '],
-            'only-basic' => ['Basic'],
+            'empty-header' => [[]],
+            'missing-basic-prefix' => [['foo']],
+            'only-username' => [['Basic ' . base64_encode('Aladdin')]],
+            'username-with-colon' => [['Basic ' . base64_encode('Aladdin:')]],
+            'password-without-username' => [['Basic ' . base64_encode(':OpenSesame')]],
+            'base64-encoded-pile-of-poo-emoji' => [['Basic ' . base64_encode('💩')]],
+            'password-containing-colon' => [['Basic ' . base64_encode('username:password:containing:colons:')]],
+            'only-one-colon' => [['Basic ' . base64_encode(':')]],
+            'multiple-colons' => [['Basic ' . base64_encode(':::::::')]],
+            'pile-of-poo-emoji' => [['Basic 💩']],
+            'only-pile-of-poo-emoji' => [['💩']],
+            'basic-prefix-without-content' => [['Basic ']],
+            'only-basic' => [['Basic']],
         ];
     }
 
     public function provideValidAuthentication(): array
     {
         return [
-            'aladdin' => ['Aladdin', 'OpenSesame', 'Basic ' . base64_encode('Aladdin:OpenSesame')],
-            'passwords-with-colon' => ['Aladdin', 'Open:Sesame', 'Basic ' . base64_encode('Aladdin:Open:Sesame')],
+            'aladdin' => ['Aladdin', 'OpenSesame', ['Basic ' . base64_encode('Aladdin:OpenSesame')]],
+            'passwords-with-colon' => ['Aladdin', 'Open:Sesame', ['Basic ' . base64_encode('Aladdin:Open:Sesame')]],
             'passwords-with-multiple-colons' => [
                 'Aladdin',
                 ':Open:Sesame:',
-                'Basic ' . base64_encode('Aladdin::Open:Sesame:')
+                ['Basic ' . base64_encode('Aladdin::Open:Sesame:')]
             ],
         ];
     }


### PR DESCRIPTION
This fixes #8 

If the authorization header contains a base64 encoded string, that contains no colon when decoded, a PHP Warning is thrown in PHP 7.2. The new/fixed behaviour is that null is returned as authentication is not possible.

I also refactored the tests along with the authentication method. The test now include much more test-cases with increased readability by using named data-providers in PHPUnit.

I also added a test-case for a password that contains colons which also did not work before. I did not open a issue for this and fixed it silently in this PR.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [x] Add a `CHANGELOG.md` entry for the fix.

